### PR TITLE
Fixed sampleReads() to avoid potential truncation of final read ID.

### DIFF
--- a/scripts/p3x-assembly.py
+++ b/scripts/p3x-assembly.py
@@ -539,6 +539,8 @@ def sampleReads(filename, details=None):
             else:
                 seq += line.rstrip()
     max_read_length = max(readLengths)
+    if len(read_id_sample) > 1:
+        read_id_sample = read_id_sample[:-1] # last entry might be truncated, avoid it
     LOG.write("read type %s, maximum read length %.1f\n"%(read_format, max_read_length))
     return read_id_sample, max_read_length
 
@@ -921,6 +923,8 @@ def writeSpadesYamlFile(details):
         OUT.write("\"\n    ]\n  }\n")
         precedingElement = True
     if interleaved_reads:
+        if precedingElement:
+            OUT.write(",\n")
         OUT.write("  {\n    type: \"paired-end\",\n    interlaced reads: [\n        \"")
         OUT.write("\",\n        \"".join(interleaved_reads))
         OUT.write("\"\n    ]\n  }\n")


### PR DESCRIPTION
Fixed problem in user job 406905 on 28 Jan. In sample of read IDs, final one was truncated, making it look like reads were not paired. Now omits last element.